### PR TITLE
added databases for dev and test env

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -5,6 +5,13 @@ framework:
     router:   { resource: "%kernel.root_dir%/config/routing_dev.yml" }
     profiler: { only_exceptions: false }
 
+doctrine:
+    dbal:
+        dbname:   ipsum_dev
+
+doctrine_mongodb:
+    default_database: ipsum_dev
+
 web_profiler:
     toolbar: true
     intercept_redirects: false

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -6,6 +6,13 @@ framework:
     session:
         storage_id: session.storage.filesystem
 
+doctrine:
+    dbal:
+        dbname:   ipsum_test
+
+doctrine_mongodb:
+    default_database: ipsum_test
+
 web_profiler:
     toolbar: false
     intercept_redirects: false


### PR DESCRIPTION
The databases for dev and test env are set to production due to configuration imports. This should not be bundled this way.
